### PR TITLE
Metadata command

### DIFF
--- a/src/MetadataUtility/Commands/Metadata/Metadata.cs
+++ b/src/MetadataUtility/Commands/Metadata/Metadata.cs
@@ -13,19 +13,22 @@ namespace MetadataUtility.Commands.Metadata
     using System.Threading.Tasks;
     using LanguageExt;
     using LanguageExt.Common;
+    using Microsoft.Extensions.Logging;
     using MetadataUtility.Extensions.System;
     using MetadataUtility.Filenames;
+    using MetadataUtility.Models;
     using MetadataUtility.Utilities;
-    using Microsoft.Extensions.Logging;
     using NodaTime;
 
-    public class Metadata : EmuCommandHandler {
+    public class Metadata : EmuCommandHandler
+    {
         private readonly ILogger<Metadata> logger;
         private readonly IFileSystem fileSystem;
         private readonly FileMatcher fileMatcher;
         private readonly OutputRecordWriter writer;
 
-        public Metadata(ILogger<Metadata> logger, IFileSystem fileSystem, FileMatcher fileMatcher, OutputRecordWriter writer) {
+        public Metadata(ILogger<Metadata> logger, IFileSystem fileSystem, FileMatcher fileMatcher, OutputRecordWriter writer)
+        {
             this.logger = logger;
             this.fileSystem = fileSystem;
             this.fileMatcher = fileMatcher;
@@ -38,10 +41,16 @@ namespace MetadataUtility.Commands.Metadata
 
         public override async Task<int> InvokeAsync(InvocationContext context)
         {
-            Console.WriteLine("Hello");
+            var files = this.fileMatcher.ExpandMatches(Directory.GetCurrentDirectory(), this.Targets);
 
-            this.logger.LogWarning("Warn");
-            this.logger.LogDebug("Hello");
+            foreach ((string, string) file in files)
+            {
+                Recording recording = new Recording();
+
+                recording.SourcePath = file.Item2;
+
+                this.writer.Write(recording);
+            }
 
             return 0;
         }

--- a/test/MetadataUtility.Tests/Commands/Metadata/MetadataCommandTests.cs
+++ b/test/MetadataUtility.Tests/Commands/Metadata/MetadataCommandTests.cs
@@ -4,13 +4,36 @@
 
 namespace MetadataUtility.Tests.Commands.Metadata
 {
+    using FluentAssertions;
+    using MetadataUtility.Commands.Metadata;
+    using MetadataUtility.Tests.TestHelpers;
+    using MetadataUtility.Utilities;
+    using MetadataUtility.Serialization;
+    using System;
+    using System.IO;
     using System.CommandLine.Parsing;
     using System.Linq;
-    using MetadataUtility.Commands;
     using Xunit;
+    using Xunit.Abstractions;
 
-    public class MetadataCommandTests
+    public class MetadataCommandTests : TestBase
     {
+        private readonly Metadata command;
+        private StringWriter sw;
+
+        public MetadataCommandTests(ITestOutputHelper output)
+            : base(output)
+        {
+            this.sw = new StringWriter();
+
+            this.command = new Metadata(
+                this.BuildLogger<Metadata>(),
+                this.TestFiles,
+                new FileMatcher(this.BuildLogger<FileMatcher>(), this.TestFiles),
+                new OutputRecordWriter(sw, new JsonLinesSerializer()));
+
+            this.command.Targets = "/".AsArray();
+        }
         [Fact]
         public void HasAMetadataCommandThatComplainsIfNoArgumentsAreGiven()
         {
@@ -27,6 +50,26 @@ namespace MetadataUtility.Tests.Commands.Metadata
             var errorLevel = result.Invoke();
 
             Assert.Equal(1, errorLevel);
+        }
+
+        [Fact]
+        public async void MetadataCommandOutputsOneRecordPerFile()
+        {
+
+            this.TestFiles.AddEmptyFile("/a.WAV");
+            this.TestFiles.AddEmptyFile("/b.WAV");
+            this.TestFiles.AddEmptyFile("/c.WAV");
+
+            var result = await this.command.InvokeAsync(null);
+
+            result.Should().Be(0);
+
+            string[] lines = sw.ToString().Split("\n").Where(s => (s.Length() > 0 && s[0] == '{')).ToArray();
+
+            Assert.Equal(lines.Length(), 3);
+            Assert.True(lines[0].Contains("a.WAV"));
+            Assert.True(lines[1].Contains("b.WAV"));
+            Assert.True(lines[2].Contains("c.WAV"));
         }
     }
 }


### PR DESCRIPTION
Metadata command now produces dummy metadata output for each given file, in the given format. Tests coming.