### PR TITLE
Extend logfile extraction

### DIFF
--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -17,59 +17,58 @@ This document outlines all of the files from which we hope to extract metadata.
 
 ## WAVE Files
 
-| Name                     | Supported | Location(s)  | Notes               |
-| ------------------------ | --------- | ------------ | ------------------- |
-| Sample Rate              | ✔️        | Header  |                     |
-| Duration                 | ✔️        | Header  |                     |
-| Total Samples            | ✔️        | Header  |                     |
-| Audio Format             | ✔️        | Header  |                     |
-| Channel Count            | ✔️        | Header  |                     |
-| Byte Rate                | ✔️        | Header  |                     |
-| Block Align              | ✔️        | Header  |                     |
-| Bit Depth                | ✔️        | Header  |                     |
-| Bits per Sample          | ✔️        | Header  |                     |
-| File Size                | ✔️        | Header  |                     |
+| Name            | Supported | Location(s) | Notes |
+| --------------- | --------- | ----------- | ----- |
+| Sample Rate     | ✔️         | Header      |       |
+| Duration        | ✔️         | Header      |       |
+| Total Samples   | ✔️         | Header      |       |
+| Audio Format    | ✔️         | Header      |       |
+| Channel Count   | ✔️         | Header      |       |
+| Byte Rate       | ✔️         | Header      |       |
+| Block Align     | ✔️         | Header      |       |
+| Bit Depth       | ✔️         | Header      |       |
+| Bits per Sample | ✔️         | Header      |       |
+| File Size       | ✔️         | Header      |       |
 
 
 ## Frontier Labs
 
 ### BAR-LT
 
-| Name                     | Supported | Location(s)     | Notes       |
-| ------------------------ | --------- | --------------- | ----------- |
-| Date Time                | ✔️         | Name, Header    |             |
-| UTC Offset               | ✔️         | Name, Header    |             |
-| Serial Number            | ✔️         | Header, Support | Log file    |
-| Microphone Serial Number | ✔️(Header) | Header, Support | Log file    |
-| Microphone Type          | ✔️(Header) | Header, Support | Log file    |
-| Microphone ID            | ✔️(Header) | Header, Support | Log file    |
-| Microphone Build Date    | ✔️(Header) | Header, Support | Log file    |
-| Microphone Channel       | ✔️(Header) | Header, Support | Log file    |
-| Longitude                | ✔️(Header, Name) | Header, Name, Support   | GPS_log.csv |
-| Latitude                 | ✔️(Header, Name) | Header, Name, Support   | GPS_log.csv |
-| Gain                     | ✔️(Header) | Header, Support | Log file    |
-| Battery Voltage          | ✔️(Header) | Header, Support | Log file    |
-| Card Slot Number         | ❌         | Header, Support | Log file    |
-| Battery Percentage       | ✔️(Header) | Header, Support | Log file    |
-| Device Type              | ❌         | Header, Support | Log file    |
-| Power Type               | ✔️         | Support         | Log file    |
-| Last Time Sync           | ✔️         | Header          |             |
-| ARU Firmware             | ✔️         | Header, Support | Log file    |
-| ARU Manufacture Date     | ❌         | Header, Support | Log file    |
-| SD Capacity (GB)         | ✔️(Support)| Support         | Log file    |
-| SD Free Space (GB)       | ❌         | Support         | Log file    |
-| SD Card Serial           | ✔️         | Header, Support | Log file    |
-| SD Card Manufacture Date | ✔️         | Header, Support | Log file    |
-| SD Card Speed            | ✔️         | Support         | Log file    |
-| SD Card Product Name     | ✔️         | Header, Support | Log file    |
-| SD Format Type           | ✔️         | Support         | Log file    |
-| SD Card Manufacture ID   | ✔️         | Header, Support | Log file    |
-| SD Card OemID            | ✔️         | Header, Support | Log file    |
-| SD Card Product Revision | ✔️         | Header, Support | Log file    |
-| SD Write Current Vmin    | ✔️         | Support         | Log file    |
-| SD Write Current Vmax    | ✔️         | Support         | Log file    |
-| SD Write Bl Size         | ✔️         | Support         | Log file    |
-| SD Erase Bl Size         | ✔️         | Support         | Log file    |
+| Name                     | Supported | Location(s)           | Notes       |
+| ------------------------ | --------- | --------------------- | ----------- |
+| Date Time                | ✔️         | Name, Header          |             |
+| UTC Offset               | ✔️         | Name, Header          |             |
+| Serial Number            | ✔️         | Header, Support       | Log file    |
+| Microphone Type          | ✔️         | Header, Support       | Log file    |
+| Microphone ID            | ✔️(Header) | Header, Support       | Log file    |
+| Microphone Build Date    | ✔️         | Header, Support       | Log file    |
+| Microphone Channel       | ✔️         | Header, Support       | Log file    |
+| Longitude                | ✔️         | Header, Name, Support | GPS_log.csv |
+| Latitude                 | ✔️         | Header, Name, Support | GPS_log.csv |
+| Gain                     | ✔️(Header) | Header, Support       | Log file    |
+| Battery Voltage          | ✔️         | Header, Support       | Log file    |
+| Card Slot Number         | ❌         | Header, Support       | Log file    |
+| Battery Percentage       | ✔️         | Header, Support       | Log file    |
+| Device Type              | ❌         | Header, Support       | Log file    |
+| Power Type               | ✔️         | Support               | Log file    |
+| Last Time Sync           | ✔️         | Header                |             |
+| ARU Firmware             | ✔️         | Header, Support       | Log file    |
+| ARU Manufacture Date     | ❌         | Header, Support       | Log file    |
+| SD Capacity (GB)         | ✔️         | Support               | Log file    |
+| SD Free Space (GB)       | ❌         | Support               | Log file    |
+| SD Card Serial           | ✔️         | Header, Support       | Log file    |
+| SD Card Manufacture Date | ✔️         | Header, Support       | Log file    |
+| SD Card Speed            | ✔️         | Support               | Log file    |
+| SD Card Product Name     | ✔️         | Header, Support       | Log file    |
+| SD Format Type           | ✔️         | Support               | Log file    |
+| SD Card Manufacture ID   | ✔️         | Header, Support       | Log file    |
+| SD Card OemID            | ✔️         | Header, Support       | Log file    |
+| SD Card Product Revision | ✔️         | Header, Support       | Log file    |
+| SD Write Current Vmin    | ✔️         | Support               | Log file    |
+| SD Write Current Vmax    | ✔️         | Support               | Log file    |
+| SD Write Bl Size         | ✔️         | Support               | Log file    |
+| SD Erase Bl Size         | ✔️         | Support               | Log file    |
 
 ### BAR
 
@@ -92,7 +91,7 @@ This document outlines all of the files from which we hope to extract metadata.
 
 | Name            | Supported | Location(s) | Notes        |
 | --------------- | --------- | ----------- | ------------ |
-| Date Time       | ✔️        | Name        |              |
+| Date Time       | ✔️         | Name        |              |
 | Serial Number   | ❌         | Header      |              |
 | Longitude       | ❌         | Header      |              |
 | Latitude        | ❌         | Header      |              |

--- a/src/MetadataUtility/Audio/Vendors/FrontierLabs.cs
+++ b/src/MetadataUtility/Audio/Vendors/FrontierLabs.cs
@@ -43,16 +43,16 @@ namespace MetadataUtility.Audio.Vendors
         public static readonly Dictionary<string, Func<string, Fin<object>>> CommentParsers = new Dictionary<string, Func<string, Fin<object>>>
         {
             { FirmwareCommentKey, FirmwareParser },
-            { RecordingStartCommentKey, DateParser },
-            { RecordingEndCommentKey, DateParser },
+            { RecordingStartCommentKey, OffsetDateTimeParser },
+            { RecordingEndCommentKey, OffsetDateTimeParser },
             { BatteryLevelCommentKey, BatteryParser },
             { LocationCommentKey, LocationParser },
-            { LastSyncCommentKey, DateParser },
+            { LastSyncCommentKey, OffsetDateTimeParser },
             { SensorIdCommentKey, GenericParser },
             { SdCidCommentKey, SdCidParser },
             { MicrophoneTypeCommentKey, GenericParser },
             { MicrophoneUIDCommentKey, GenericParser },
-            { MicrophoneBuildDateCommentKey, GenericParser },
+            { MicrophoneBuildDateCommentKey, DateParser },
             { MicrophoneGainCommentKey, NumericParser },
         };
 
@@ -229,11 +229,11 @@ namespace MetadataUtility.Audio.Vendors
         }
 
         /// <summary>
-        /// Frontier Labs vorbis comment date parser.
+        /// Frontier Labs vorbis comment offset date time parser.
         /// </summary>
         /// <param name="value">The value to parse.</param>
         /// <returns>The parsed date.</returns>
-        public static Fin<object> DateParser(string value)
+        public static Fin<object> OffsetDateTimeParser(string value)
         {
             OffsetDateTime? date = null;
 
@@ -257,6 +257,13 @@ namespace MetadataUtility.Audio.Vendors
 
             return date;
         }
+
+        /// <summary>
+        /// Frontier Labs vorbis comment date parser.
+        /// </summary>
+        /// <param name="value">The value to parse.</param>
+        /// <returns>The parsed date.</returns>
+        public static Fin<object> DateParser(string value) => LocalDatePattern.CreateWithInvariantCulture("yyyy'-'MM'-'dd").Parse(value).Value;
 
         /// <summary>
         /// Frontier Labs vorbis comment location parser.

--- a/src/MetadataUtility/Metadata/FrontierLabs/FlacCommentExtractor.cs
+++ b/src/MetadataUtility/Metadata/FrontierLabs/FlacCommentExtractor.cs
@@ -53,7 +53,7 @@ namespace MetadataUtility.Metadata.FrontierLabs
                     {
                         Type = (string)this.ParseComment(FrontierLabs.MicrophoneTypeCommentKey + micNumber, comments),
                         UID = (string)this.ParseComment(FrontierLabs.MicrophoneUIDCommentKey + micNumber, comments),
-                        BuildDate = (string)this.ParseComment(FrontierLabs.MicrophoneBuildDateCommentKey + micNumber, comments),
+                        BuildDate = (LocalDate?)this.ParseComment(FrontierLabs.MicrophoneBuildDateCommentKey + micNumber, comments),
                         Gain = (double?)this.ParseComment(FrontierLabs.MicrophoneGainCommentKey + micNumber, comments),
                         Channel = micNumber,
                         ChannelName = channelName,

--- a/src/MetadataUtility/Metadata/FrontierLabs/LogFileExtractor.cs
+++ b/src/MetadataUtility/Metadata/FrontierLabs/LogFileExtractor.cs
@@ -18,13 +18,22 @@ namespace MetadataUtility.Metadata.FrontierLabs
             this.logger = logger;
         }
 
-        public static MemoryCard CorrelateSD(List<(MemoryCard MemoryCard, int ItemNumber)> memoryCardLogs, LogFile.RecordingRecord recording)
+        /// <summary>
+        /// Correlates memory card to its corresponding recording.
+        /// Uses item number which keeps track of the relative position of memory cards and recordings in the log file.
+        /// </summary>
+        /// <param name="memoryCardLogs">List of all memory cards found in the log file and their relative positions.</param>
+        /// <param name="recordingItemNumber">Relative order of the recording in the log file.</param>
+        /// <returns>
+        /// The corresponding memory card.
+        /// </returns>
+        public static MemoryCard CorrelateSD(List<(MemoryCard MemoryCard, int ItemNumber)> memoryCardLogs, int recordingItemNumber)
         {
             MemoryCard memoryCard = memoryCardLogs[0].MemoryCard;
 
             foreach ((MemoryCard currentMemoryCard, int itemNumber) in memoryCardLogs)
             {
-                if (itemNumber < recording.ItemNumber)
+                if (itemNumber < recordingItemNumber)
                 {
                     memoryCard = currentMemoryCard;
                 }
@@ -64,7 +73,7 @@ namespace MetadataUtility.Metadata.FrontierLabs
             }
             else if (recordingRecord != null)
             {
-                memoryCard = CorrelateSD(logFile.MemoryCardLogs, recordingRecord);
+                memoryCard = CorrelateSD(logFile.MemoryCardLogs, recordingRecord.ItemNumber);
             }
 
             if (memoryCard != null)

--- a/src/MetadataUtility/Metadata/FrontierLabs/LogFileExtractor.cs
+++ b/src/MetadataUtility/Metadata/FrontierLabs/LogFileExtractor.cs
@@ -46,14 +46,17 @@ namespace MetadataUtility.Metadata.FrontierLabs
 
         public ValueTask<Recording> ProcessFileAsync(TargetInformation information, Recording recording)
         {
+            // Retrieve all information parsed from the log file
             LogFile logFile = (LogFile)information.TargetSupportFiles[LogFile.LogFileKey];
-            MemoryCard memoryCard = null;
             Sensor sensor = logFile.Sensor;
 
             string filename = information.FileSystem.Path.GetFileName(information.Path);
             var recordingRecord = logFile.RecordingLogs.Where(x => x.Name.Contains(filename)).FirstOrDefault();
 
             var serialNumbers = logFile.MemoryCardLogs.Select(x => x.MemoryCard?.SerialNumber);
+
+            // Correlate memory card data
+            MemoryCard memoryCard = null;
 
             if (serialNumbers.Distinct().Count() == 1)
             {

--- a/src/MetadataUtility/Metadata/SupportFiles/FrontierLabs/LogFile.cs
+++ b/src/MetadataUtility/Metadata/SupportFiles/FrontierLabs/LogFile.cs
@@ -154,6 +154,7 @@ namespace MetadataUtility.Metadata.SupportFiles.FrontierLabs
 
         /// <summary>
         /// Parses a location from a log file.
+        /// Example location format: [+43.70588-065.95160]
         /// </summary>
         /// <param name="value">The unparsed location value.</param>
         /// <returns>
@@ -181,6 +182,7 @@ namespace MetadataUtility.Metadata.SupportFiles.FrontierLabs
 
         /// <summary>
         /// Parses battery data from a log file.
+        /// Example batter data format: 94% ( 4.13 V )
         /// </summary>
         /// <param name="value">The unparsed battery data.</param>
         /// <returns>
@@ -199,6 +201,7 @@ namespace MetadataUtility.Metadata.SupportFiles.FrontierLabs
 
         /// <summary>
         /// Parses a microphone from a log file.
+        /// Example microphone data format: Ch A: 006277 "STD AUDIO MIC" ( 16/01/2020 )
         /// </summary>
         /// <param name="value">The unparsed microphone value.</param>
         /// <returns>

--- a/src/MetadataUtility/Metadata/SupportFiles/FrontierLabs/LogFile.cs
+++ b/src/MetadataUtility/Metadata/SupportFiles/FrontierLabs/LogFile.cs
@@ -182,7 +182,7 @@ namespace MetadataUtility.Metadata.SupportFiles.FrontierLabs
 
         /// <summary>
         /// Parses battery data from a log file.
-        /// Example batter data format: 94% ( 4.13 V )
+        /// Example battery data format: <c>94% ( 4.13 V )</c>.
         /// </summary>
         /// <param name="value">The unparsed battery data.</param>
         /// <returns>

--- a/src/MetadataUtility/Metadata/SupportFiles/FrontierLabs/LogFile.cs
+++ b/src/MetadataUtility/Metadata/SupportFiles/FrontierLabs/LogFile.cs
@@ -201,7 +201,7 @@ namespace MetadataUtility.Metadata.SupportFiles.FrontierLabs
 
         /// <summary>
         /// Parses a microphone from a log file.
-        /// Example microphone data format: Ch A: 006277 "STD AUDIO MIC" ( 16/01/2020 )
+        /// Example microphone data format: <c>Ch A: 006277 "STD AUDIO MIC" ( 16/01/2020 )</c>.
         /// </summary>
         /// <param name="value">The unparsed microphone value.</param>
         /// <returns>

--- a/src/MetadataUtility/Metadata/SupportFiles/FrontierLabs/LogFile.cs
+++ b/src/MetadataUtility/Metadata/SupportFiles/FrontierLabs/LogFile.cs
@@ -41,7 +41,7 @@ namespace MetadataUtility.Metadata.SupportFiles.FrontierLabs
         /// Searches each potential support file for a log file that correlates with the given recording.
         /// </summary>
         /// <param name="information">The target recording information.</param>
-        /// <param name="supportFiles">List of all potential support files for this target.</param>       
+        /// <param name="supportFiles">List of all potential support files for this target.</param>
         public static void FindLogFile(TargetInformation information, IEnumerable<string> supportFiles)
         {
             IEnumerable<string> logFiles = supportFiles.Where(x => LogFileRegex.IsMatch(x));
@@ -92,7 +92,7 @@ namespace MetadataUtility.Metadata.SupportFiles.FrontierLabs
         /// If the given log file has already been cached, find and return it.
         /// If this is an unseen log file, parse all of it's data and return it.
         /// </summary>
-        /// <param name="log">The log file name.</param>  
+        /// <param name="log">The log file name.</param>
         /// <returns>
         /// A parsed log file object.
         /// </returns>

--- a/src/MetadataUtility/Metadata/SupportFiles/FrontierLabs/LogFile.cs
+++ b/src/MetadataUtility/Metadata/SupportFiles/FrontierLabs/LogFile.cs
@@ -154,7 +154,7 @@ namespace MetadataUtility.Metadata.SupportFiles.FrontierLabs
 
         /// <summary>
         /// Parses a location from a log file.
-        /// Example location format: [+43.70588-065.95160]
+        /// Example location format: <c>[+43.70588-065.95160]</c>.
         /// </summary>
         /// <param name="value">The unparsed location value.</param>
         /// <returns>

--- a/src/MetadataUtility/Metadata/SupportFiles/SupportFile.cs
+++ b/src/MetadataUtility/Metadata/SupportFiles/SupportFile.cs
@@ -80,6 +80,7 @@ namespace MetadataUtility.Metadata.SupportFiles
         /// Extracts all useful information out of the support file.
         /// This should done only once for each support file, the result should then be cached in KnownSupportFiles (TargetInformation.cs).
         /// </summary>
-        public abstract void ExtractInformation();
+        /// <returns>True if extracted succesfully, false if not.</returns>
+        public abstract bool ExtractInformation();
     }
 }

--- a/src/MetadataUtility/Models/Microphone.cs
+++ b/src/MetadataUtility/Models/Microphone.cs
@@ -34,7 +34,7 @@ namespace MetadataUtility.Models
         /// <summary>
         /// Gets microphone number according to the sensor (1, 2, etc.).
         /// </summary>
-        public int Channel { get; init; }
+        public int? Channel { get; init; }
 
         /// <summary>
         /// Gets the name of the microphone (style depends on vendor).

--- a/src/MetadataUtility/Models/Microphone.cs
+++ b/src/MetadataUtility/Models/Microphone.cs
@@ -4,6 +4,8 @@
 
 namespace MetadataUtility.Models
 {
+    using NodaTime;
+
     /// <summary>
     /// Holds information regarding a microphone
     /// that is attached to the device.
@@ -23,7 +25,7 @@ namespace MetadataUtility.Models
         /// <summary>
         /// Gets the build date of this microphone.
         /// </summary>
-        public string BuildDate { get; init; }
+        public LocalDate? BuildDate { get; init; }
 
         /// <summary>
         /// Gets the gain of this microphone.

--- a/test/Fixtures/Fixtures.yaml
+++ b/test/Fixtures/Fixtures.yaml
@@ -319,7 +319,7 @@
       WrCurrentVmax: 3
       WriteBlSize: 512
       EraseBlSize: 65536
-    Sensor:
+    Sensor: &GlitchySignalSensor
       Name:
       Firmware: 3.14
       SerialNumber: 53373100-38324832-30303430-39323032
@@ -361,7 +361,18 @@
       LocalStartDate: 2019-11-25T23:59:00
       Location: ~
     FlacHeaderExtractor: ~
-    FrontierLabsLogFileExtractor: ~
+    FrontierLabsLogFileExtractor:
+      <<: *GlitchySignal
+      Sensor:
+        <<: *GlitchySignalSensor
+        Microphones:
+        - Type: STD AUDIO MIC
+          UID: 000610
+          BuildDate: 2019-02-22
+          Gain:
+          Channel:
+          ChannelName:
+          Sensitivity:
     FlacCommentExtractor: ~
 
 - Name: Short File
@@ -398,7 +409,7 @@
       WrCurrentVmax: 3
       WriteBlSize: 512
       EraseBlSize: 65536
-    Sensor:
+    Sensor: &ShortFileSensor
       Name:
       Firmware: 3.14
       SerialNumber: 53373100-38324832-30303430-39323032
@@ -440,7 +451,18 @@
       LocalStartDate: 2019-11-04T02:00:00
       Location: ~
     FlacHeaderExtractor: ~
-    FrontierLabsLogFileExtractor: ~
+    FrontierLabsLogFileExtractor:
+      <<: *ShortFile
+      Sensor:
+        <<: *ShortFileSensor
+        Microphones:
+          - Type: STD AUDIO MIC
+            UID: 000610
+            BuildDate: 2019-02-22
+            Gain:
+            Channel:
+            ChannelName:
+            Sensitivity:
     FlacCommentExtractor: ~
 
 - Name: Two Log Files 1
@@ -485,8 +507,8 @@
       Microphones:
       Gain:
       Configuration:
-      Voltage:
-      BatteryLevel:
+      Voltage: 3.21
+      BatteryLevel: 0.18
       Temperature:
       LastTimeSync:
     Location:
@@ -551,8 +573,8 @@
       Microphones:
       Gain:
       Configuration:
-      Voltage:
-      BatteryLevel:
+      Voltage: 3.94
+      BatteryLevel: 0.78
       Temperature:
       LastTimeSync:
     Location:
@@ -763,7 +785,7 @@
       WrCurrentVmax: 5
       WriteBlSize: 512
       EraseBlSize: 65536
-    Sensor:
+    Sensor: &Firmware3.3Sensor
       Name:
       Firmware: 3.30
       SerialNumber: 00008570
@@ -811,4 +833,16 @@
       MemoryCard:
         <<: *Firmware3.3MemoryCard
         SerialNumber: 8041328
+      Sensor:
+        <<: *Firmware3.3Sensor
+        BatteryLevel: 0.63
+        Voltage: 3.75
+        Microphones:
+        - Type: STD AUDIO MIC
+          UID: 009966
+          BuildDate: 2019-03-20
+          Gain:
+          Channel: 2
+          ChannelName: B
+          Sensitivity:
     FLCommentAndLogExtractor: ~

--- a/test/MetadataUtility.Tests/Metadata/FrontierLabs/LogFileExtractorTests.cs
+++ b/test/MetadataUtility.Tests/Metadata/FrontierLabs/LogFileExtractorTests.cs
@@ -56,6 +56,9 @@ namespace MetadataUtility.Tests.Metadata
                 recording.Sensor.Firmware.Should().Be(expectedRecording.Sensor.Firmware);
                 recording.Sensor.SerialNumber.Should().Be(expectedRecording.Sensor.SerialNumber);
                 recording.Sensor.PowerSource.Should().Be(expectedRecording.Sensor.PowerSource);
+                recording.Sensor.BatteryLevel.Should().Be(expectedRecording.Sensor.BatteryLevel);
+                recording.Sensor.Voltage.Should().Be(expectedRecording.Sensor.Voltage);
+                recording.Sensor.Microphones.Should().BeEquivalentTo(expectedRecording.Sensor.Microphones);
             }
         }
     }


### PR DESCRIPTION
Extended the FL log file extraction to parse some additional values that seem to only be included in more recent firmware versions (at least > 3.03). Namely battery, microphone and location values. For a good chunk of our files these can only be parsed from the log file (not included in FL wave files).

Also refactored the log file parser a bit (creating smaller parsing methods rather than parsing everything in one chunky method).