### PR TITLE
Improve rational CSV serialization

### DIFF
--- a/src/MetadataUtility/Serialization/Converters/RationalsConverter.cs
+++ b/src/MetadataUtility/Serialization/Converters/RationalsConverter.cs
@@ -12,6 +12,16 @@ namespace MetadataUtility.Serialization.Converters
 
     public class RationalsConverter : DefaultTypeConverter
     {
+        public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+        {
+            if (value == null)
+            {
+                return string.Empty;
+            }
+
+            return ((double)((Rational)value)).ToString();
+        }
+
         public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
             if (text != null)


### PR DESCRIPTION
I noticed duration (Rational) is being represented as a messy fraction in the CSV. Cast to a double for cleaner representation when serializing.