### PR TITLE
Small fixes

### DIFF
--- a/src/MetadataUtility/Audio/Wave.cs
+++ b/src/MetadataUtility/Audio/Wave.cs
@@ -360,7 +360,7 @@ namespace MetadataUtility.Audio
                     // TODO: Fix this problem rather than cover it up
                     if (offset + length - stream.Length == FL005ErrorBytes)
                     {
-                        length -= FL005Patch(length);
+                        length = FL005Patch(length);
                     }
                     else
                     {

--- a/src/MetadataUtility/Audio/Wave.cs
+++ b/src/MetadataUtility/Audio/Wave.cs
@@ -24,6 +24,7 @@ namespace MetadataUtility.Audio
         public const string Mime = "audio/wave";
 
         public const int MinimumRiffHeaderLength = 8;
+        public const int FL005ErrorBytes = 44;
 
         public static readonly byte[] RiffMagicNumber = new byte[] { (byte)'R', (byte)'I', (byte)'F', (byte)'F' };
         public static readonly byte[] WaveMagicNumber = new byte[] { (byte)'W', (byte)'A', (byte)'V', (byte)'E' };
@@ -292,6 +293,8 @@ namespace MetadataUtility.Audio
             return length / (ulong)(channels * (bitsPerSample / 8));
         }
 
+        public static int FL005Patch(int length) => length - FL005ErrorBytes;
+
         /// <summary>
         /// Scans a container (a range of bytes) for a sub-chunk with the given chunk ID.
         /// The target chunk may be in any position within it's siblings.
@@ -355,9 +358,9 @@ namespace MetadataUtility.Audio
                 {
                     // FL005 is detected - decrement length by 44 for an accurate value
                     // TODO: Fix this problem rather than cover it up
-                    if (offset + length - stream.Length == 44)
+                    if (offset + length - stream.Length == FL005ErrorBytes)
                     {
-                        length -= 44;
+                        length -= FL005Patch(length);
                     }
                     else
                     {

--- a/src/MetadataUtility/Audio/Wave.cs
+++ b/src/MetadataUtility/Audio/Wave.cs
@@ -284,12 +284,12 @@ namespace MetadataUtility.Audio
             return bitsPerSample;
         }
 
-        public static uint GetTotalSamples(RangeHelper.Range dataChunk, ushort channels, ushort bitsPerSample)
+        public static ulong GetTotalSamples(RangeHelper.Range dataChunk, ushort channels, ushort bitsPerSample)
         {
             // size of the data chunk
-            var length = (uint)dataChunk.Length;
+            var length = (ulong)dataChunk.Length;
 
-            return length / (uint)(channels * (bitsPerSample / 8));
+            return length / (ulong)(channels * (bitsPerSample / 8));
         }
 
         /// <summary>
@@ -353,7 +353,16 @@ namespace MetadataUtility.Audio
                 // check the chunk length falls within the bounds of the file
                 if (offset + length > stream.Length)
                 {
-                    return InvalidChunk;
+                    // FL005 is detected - decrement length by 44 for an accurate value
+                    // TODO: Fix this problem rather than cover it up
+                    if (offset + length - stream.Length == 44)
+                    {
+                        length -= 44;
+                    }
+                    else
+                    {
+                        return InvalidChunk;
+                    }
                 }
 
                 // check whether we found our target chunk or not

--- a/src/MetadataUtility/Metadata/WaveHeaderExtractor.cs
+++ b/src/MetadataUtility/Metadata/WaveHeaderExtractor.cs
@@ -49,15 +49,16 @@ namespace MetadataUtility.Metadata
             var byteRate = Wave.GetByteRate(formatSpan);
             var channels = Wave.GetChannels(formatSpan);
 
-            var samples = dataChunk.Map(d => Wave.GetTotalSamples(d, channels, bitsPerSample));
+            var samples = dataChunk.Map(d => (ulong?)Wave.GetTotalSamples(d, channels, bitsPerSample));
             var fileLength = stream.Length;
 
             // TODO: replace with rational type from master branch
-            var duration = samples.Map(s => (Rational?)new Rational((uint)samples, (uint)sampleRate));
+            var duration = samples.Map(s => (Rational?)new Rational((uint)samples!, (uint)sampleRate));
 
             return ValueTask.FromResult(recording with
             {
                 DurationSeconds = duration.IfFail((Rational?)null),
+                TotalSamples = samples.IfFail((ulong?)null),
                 SampleRateHertz = sampleRate,
                 Channels = (ushort)channels,
                 BitsPerSecond = byteRate * BinaryHelpers.BitsPerByte,

--- a/src/MetadataUtility/Models/Recording.cs
+++ b/src/MetadataUtility/Models/Recording.cs
@@ -178,15 +178,6 @@ namespace MetadataUtility.Models
         public OffsetDateTime? EndDate { get; init; }
 
         /// <summary>
-        /// Gets a unique identifier for the memory card
-        /// that this recording was stored on.
-        /// </summary>
-        /// <remarks>
-        /// Such as https://www.cameramemoryspeed.com/sd-memory-card-faq/reading-sd-card-cid-serial-psn-internal-numbers/.
-        /// </remarks>
-        public string StorageCardIdentifier { get; init; }
-
-        /// <summary>
         /// Gets the Expected duration of the recording.
         /// </summary>
         public Duration? ExpectedDurationSeconds { get; init; }

--- a/test/MetadataUtility.Tests/Metadata/WaveHeaderExtractorTests.cs
+++ b/test/MetadataUtility.Tests/Metadata/WaveHeaderExtractorTests.cs
@@ -48,6 +48,7 @@ namespace MetadataUtility.Tests.Metadata
                     this.Recording);
 
                 recording.DurationSeconds?.Should().Be(expectedRecording.DurationSeconds);
+                recording.TotalSamples.Should().Be(expectedRecording.TotalSamples);
                 recording.SampleRateHertz.Should().Be(expectedRecording.SampleRateHertz);
                 recording.Channels.Should().Be(expectedRecording.Channels);
                 recording.BitsPerSecond.Should().Be(expectedRecording.BitsPerSecond);

--- a/test/MetadataUtility.Tests/TestHelpers/Fakes/Fakes.cs
+++ b/test/MetadataUtility.Tests/TestHelpers/Fakes/Fakes.cs
@@ -41,7 +41,6 @@ namespace MetadataUtility.Tests.TestHelpers.Fakes
 
                 //(f, x) => Provenance.Calculated.Wrap(x.StartDate?.Value + x.DurationSeconds))
 
-                .RuleFor(x => x.StorageCardIdentifier, f => f.Random.AlphaNumeric(16))
                 .RuleFor(x => x.ExpectedDurationSeconds, f => Duration.FromHours(24));
 
             this.Checksum = new Faker<Checksum>()


### PR DESCRIPTION
Some small fixes we discusses. Removed the SD identifier field. Detected and patched FL005 by checking for a data length 44 bytes long, manually fixing it when found... left a TODO to fix the file itself.