### PR TITLE
Created no checksum option

### DIFF
--- a/src/Emu/Commands/EmuCommand.cs
+++ b/src/Emu/Commands/EmuCommand.cs
@@ -7,9 +7,7 @@ namespace Emu
     using System.CommandLine;
     using System.CommandLine.Parsing;
     using System.Diagnostics.CodeAnalysis;
-    using System.IO.Abstractions;
     using Emu.Commands.Cues;
-    using Emu.Commands.Metadata;
     using Emu.Commands.Version;
     using Emu.Extensions.System.CommandLine;
 
@@ -24,6 +22,7 @@ namespace Emu
             this.AddGlobalOption(FormatOption);
             this.AddGlobalOption(OutOption);
             this.AddGlobalOption(ClobberOption);
+            this.AddGlobalOption(NoChecksumOption);
 
             this.Add(new MetadataCommand());
             this.Add(new RenameCommand());
@@ -80,6 +79,10 @@ namespace Emu
         public static Option<bool> ClobberOption { get; } = new Option<bool>(
             new string[] { "--clobber", "-C" },
             "Overwrites output file, used in junction with --output. No effect for standard out");
+
+        public static Option<bool> NoChecksumOption { get; } = new Option<bool>(
+            new string[] { "--no-checksum", "-N" },
+            "Doesn't calculate checksum, important for archiving purposes but computationally expensive");
 
         public static LogLevel GetLogLevel(ParseResult parseResult)
         {

--- a/src/Emu/Commands/EmuCommand.cs
+++ b/src/Emu/Commands/EmuCommand.cs
@@ -81,7 +81,7 @@ namespace Emu
             "Overwrites output file, used in junction with --output. No effect for standard out");
 
         public static Option<bool> NoChecksumOption { get; } = new Option<bool>(
-            new string[] { "--no-checksum", "-N" },
+            new string[] { "--no-checksum" },
             "Doesn't calculate checksum, important for archiving purposes but computationally expensive");
 
         public static LogLevel GetLogLevel(ParseResult parseResult)

--- a/src/Emu/Commands/EmuGlobalOptions.cs
+++ b/src/Emu/Commands/EmuGlobalOptions.cs
@@ -14,6 +14,8 @@ namespace Emu
 
         public bool Clobber { get; set; }
 
+        public bool NoChecksum { get; set; }
+
         public LogLevel LogLevel { get; set; }
 
         public OutputFormat Format { get; set; }

--- a/src/Emu/Commands/Metadata/Metadata.cs
+++ b/src/Emu/Commands/Metadata/Metadata.cs
@@ -25,7 +25,7 @@ namespace Emu.Commands.Metadata
         private readonly FileMatcher fileMatcher;
 
         private readonly MetadataRegister extractorRegister;
-        private readonly IEnumerable<IMetadataOperation> allExtractors;
+        private IEnumerable<IMetadataOperation> allExtractors;
 
         public Metadata(
             ILogger<Metadata> logger,
@@ -48,6 +48,9 @@ namespace Emu.Commands.Metadata
 
         public override async Task<int> InvokeAsync(InvocationContext invocationContext)
         {
+            // Filter out HashCalculator if no checksum option is
+            this.allExtractors = this.NoChecksum ? this.allExtractors.Where(x => x is not HashCalculator) : this.allExtractors;
+
             var paths = this.fileMatcher.ExpandMatches(this.fileSystem.Directory.GetCurrentDirectory(), this.Targets);
 
             Dictionary<string, List<TargetInformation>> targetDirectories = new Dictionary<string, List<TargetInformation>>();

--- a/src/Emu/Commands/Metadata/Metadata.cs
+++ b/src/Emu/Commands/Metadata/Metadata.cs
@@ -25,7 +25,7 @@ namespace Emu.Commands.Metadata
         private readonly FileMatcher fileMatcher;
 
         private readonly MetadataRegister extractorRegister;
-        private IEnumerable<IMetadataOperation> allExtractors;
+        private readonly IEnumerable<IMetadataOperation> allExtractors;
 
         public Metadata(
             ILogger<Metadata> logger,
@@ -49,7 +49,7 @@ namespace Emu.Commands.Metadata
         public override async Task<int> InvokeAsync(InvocationContext invocationContext)
         {
             // Filter out HashCalculator if no checksum option is
-            this.allExtractors = this.NoChecksum ? this.allExtractors.Where(x => x is not HashCalculator) : this.allExtractors;
+            var filteredExtractors = this.NoChecksum ? this.allExtractors.Where(x => x is not HashCalculator) : this.allExtractors;
 
             var paths = this.fileMatcher.ExpandMatches(this.fileSystem.Directory.GetCurrentDirectory(), this.Targets);
 
@@ -87,7 +87,7 @@ namespace Emu.Commands.Metadata
                         SourcePath = target.Path,
                     };
 
-                    foreach (var extractor in this.allExtractors)
+                    foreach (var extractor in filteredExtractors)
                     {
                         if (await extractor.CanProcessAsync(target))
                         {

--- a/src/Emu/Metadata/HashCalculator.cs
+++ b/src/Emu/Metadata/HashCalculator.cs
@@ -12,16 +12,18 @@ namespace Emu.Metadata
     public class HashCalculator : IMetadataOperation
     {
         private readonly FileUtilities fileUtilities;
+        private readonly EmuGlobalOptions options;
 
-        public HashCalculator(FileUtilities fileUtilities)
+        public HashCalculator(FileUtilities fileUtilities, EmuGlobalOptions options)
         {
             this.fileUtilities = fileUtilities;
+            this.options = options;
         }
 
         public ValueTask<bool> CanProcessAsync(TargetInformation information)
         {
-            // as long as the file exists, we can calculate a hash.
-            return ValueTask.FromResult(true);
+            // Calculate the hash unless the user specifies otherwise
+            return ValueTask.FromResult(!this.options.NoChecksum);
         }
 
         public async ValueTask<Recording> ProcessFileAsync(TargetInformation information, Recording recording)

--- a/src/Emu/Metadata/HashCalculator.cs
+++ b/src/Emu/Metadata/HashCalculator.cs
@@ -12,18 +12,16 @@ namespace Emu.Metadata
     public class HashCalculator : IMetadataOperation
     {
         private readonly FileUtilities fileUtilities;
-        private readonly EmuGlobalOptions options;
 
-        public HashCalculator(FileUtilities fileUtilities, EmuGlobalOptions options)
+        public HashCalculator(FileUtilities fileUtilities)
         {
             this.fileUtilities = fileUtilities;
-            this.options = options;
         }
 
         public ValueTask<bool> CanProcessAsync(TargetInformation information)
         {
-            // Calculate the hash unless the user specifies otherwise
-            return ValueTask.FromResult(!this.options.NoChecksum);
+            // as long as the file exists, we can calculate a hash.
+            return ValueTask.FromResult(true);
         }
 
         public async ValueTask<Recording> ProcessFileAsync(TargetInformation information, Recording recording)

--- a/test/Emu.Tests/Metadata/HashCalculatorTests.cs
+++ b/test/Emu.Tests/Metadata/HashCalculatorTests.cs
@@ -17,24 +17,12 @@ namespace Emu.Tests.Metadata
     public class HashCalculatorTests : TestBase
     {
         private readonly HashCalculator subject;
-        private readonly HashCalculator noChecksumSubject;
 
         public HashCalculatorTests(ITestOutputHelper output)
             : base(output, true)
         {
             var fileUtilities = this.ServiceProvider.GetRequiredService<FileUtilities>();
-            this.subject = new HashCalculator(
-                fileUtilities,
-                new EmuGlobalOptions()
-                {
-                    NoChecksum = false,
-                });
-            this.noChecksumSubject = new HashCalculator(
-                fileUtilities,
-                new EmuGlobalOptions()
-                {
-                    NoChecksum = true,
-                });
+            this.subject = new HashCalculator(fileUtilities);
         }
 
         public Recording Recording => new();
@@ -60,15 +48,6 @@ namespace Emu.Tests.Metadata
                 this.Recording);
 
             recording.CalculatedChecksum.Should().Be(expectedRecording.CalculatedChecksum);
-        }
-
-        [Theory]
-        [ClassData(typeof(FixtureHelper.FixtureData))]
-        public async Task NoChecksumWorks(FixtureModel model)
-        {
-            var result = await this.noChecksumSubject.CanProcessAsync(model.ToTargetInformation(this.RealFileSystem));
-
-            Assert.False(result);
         }
     }
 }

--- a/test/Emu.Tests/TestHelpers/TestBase.cs
+++ b/test/Emu.Tests/TestHelpers/TestBase.cs
@@ -100,6 +100,8 @@ namespace Emu.Tests.TestHelpers
 
         public string AllOutput => this.cleanOutput.ToString();
 
+        public TextReader GetAllOutputReader() => new StringReader(this.AllOutput);
+
         public FilenameParser FilenameParser => new(
             this.TestFiles,
             this.ServiceProvider.GetRequiredService<FilenameGenerator>());


### PR DESCRIPTION
Had a go at creating the no-checksum option. Injected the option into the hash calculator itself, realizing the testing infrastructure isn't set up for that to work (makes sense). Thinking of where it would be best to inject the option, maybe in [Metadata.cs](https://github.com/QutEcoacoustics/emu/blob/master/src/Emu/Commands/Metadata/Metadata.cs)? Let me know your thoughts.

Closes #228