### PR TITLE
Makes FL011 fix more resiliant

### DIFF
--- a/src/Emu/Commands/Fix/Apply/FixApply.cs
+++ b/src/Emu/Commands/Fix/Apply/FixApply.cs
@@ -232,7 +232,7 @@ namespace Emu
             builder.Append(MarkupFileSection(f.File));
             if (f.BackupFile != null)
             {
-                builder.AppendFormat("\tBacked up to {0}", f.BackupFile.EscapeMarkup());
+                builder.AppendFormat("\tBacked up to {0}\n", f.BackupFile.EscapeMarkup());
             }
 
             foreach (var report in f.Problems)

--- a/src/Emu/Fixes/FrontierLabs/PartialFileRepair.cs
+++ b/src/Emu/Fixes/FrontierLabs/PartialFileRepair.cs
@@ -286,7 +286,7 @@ namespace Emu.Fixes.FrontierLabs
                 () => Flac.WriteTotalSamples(stream, newSamples),
                 () => Fin<Unit>.Succ(default));
 
-            using var fragementStream = this.fileSystem.File.OpenWrite(fragmentPath);
+            using var fragementStream = this.fileUtilities.FileOpenWrite(fragmentPath, dryRun);
             this.logger.LogDebug(
                 "Truncating file from {old} to {new}, fragment written to {fragment}",
                 stream.Length,

--- a/src/Emu/Metadata/FrontierLabs/FlacCommentExtractor.cs
+++ b/src/Emu/Metadata/FrontierLabs/FlacCommentExtractor.cs
@@ -91,6 +91,7 @@ namespace Emu.Metadata.FrontierLabs
                 {
                     Sensor = (recording.Sensor ?? new Sensor()) with
                     {
+                        Make = Vendor.FrontierLabs.ToNiceName(),
                         Firmware = recording.Sensor?.Firmware ?? (string)this.ParseComment(FrontierLabs.FirmwareCommentKey, comments),
                         BatteryLevel = recording.Sensor?.BatteryLevel ?? batteryLevel,
                         Voltage = recording.Sensor?.Voltage ?? voltage,

--- a/src/Emu/Utilities/FileUtilities.cs
+++ b/src/Emu/Utilities/FileUtilities.cs
@@ -138,6 +138,26 @@ namespace Emu.Utilities
             }
         }
 
+        /// <summary>
+        /// Opens a stream for writing or otherwise returns a fake stream
+        /// with no backing store.
+        /// </summary>
+        /// <param name="path">The path to create the stream at.</param>
+        /// <param name="dryRun">Whether or not to really open a file.</param>
+        /// <returns>A stream to write to.</returns>
+        public Stream FileOpenWrite(string path, DryRun dryRun)
+        {
+            ArgumentNullException.ThrowIfNull(path, nameof(path));
+
+            Stream stream = null;
+            dryRun.WouldDo(
+                "Creating file to write to at " + path,
+                () => stream = this.fileSystem.File.OpenWrite(path),
+                () => stream = FileSystemStream.Null);
+
+            return stream;
+        }
+
         public async ValueTask<Checksum> CalculateChecksumSha256(string path)
         {
             ArgumentNullException.ThrowIfNull(path, nameof(path));

--- a/test/Emu.Tests/Commands/Cues/CuesTests.cs
+++ b/test/Emu.Tests/Commands/Cues/CuesTests.cs
@@ -13,6 +13,7 @@ namespace Emu.Tests.Commands.Cues
     using Emu.Tests.TestHelpers;
     using Emu.Utilities;
     using FluentAssertions;
+    using MoreLinq;
     using Rationals;
     using Xunit;
     using Xunit.Abstractions;
@@ -114,6 +115,8 @@ namespace Emu.Tests.Commands.Cues
                 var cueFile = info.GetFiles("*.cue.txt").Single();
                 return this.CurrentFileSystem.File.ReadAllText(cueFile.FullName);
             }
+
+            targets.ForEach(x => x.Dispose());
         }
     }
 }

--- a/test/Fixtures/FL_BAR_LT/3.30_PartialDataFiles2/README.md
+++ b/test/Fixtures/FL_BAR_LT/3.30_PartialDataFiles2/README.md
@@ -1,0 +1,13 @@
+# License and Attribution
+
+These files was sourced by Doug Hynes from ECCC and are licensed to us under a
+Creative Commons By Attribution v4.0 license.
+
+
+https://github.com/QutEcoacoustics/emu/issues/346
+
+Contact https://github.com/DougPHynes
+
+This file demonstrates the FL011 problem that triggers an error in our FLAC decoder.
+
+Only 60,203,008 samples (115,080,383) bytes of this file are FLAC.

--- a/test/Fixtures/FL_BAR_LT/3.30_PartialDataFiles2/data
+++ b/test/Fixtures/FL_BAR_LT/3.30_PartialDataFiles2/data
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56180427da913b3f33b969ccb788106b4693a0f80cafbbe4cd567337d69c567c
+size 634142764

--- a/test/Fixtures/Fixtures.yaml
+++ b/test/Fixtures/Fixtures.yaml
@@ -2694,3 +2694,103 @@
     WaveHeaderExtractor: ~
     WamdExtractor: ~
     #GuanoExtractor: ~
+
+- Name: "FL011 Bug #346"
+  Record: &FL011Bug346
+    Extension:
+    Stem: data
+    StartDate: 2022-06-16T11:00:00-03:00
+    LocalStartDate: 2022-06-16T11:00:00
+    TrueStartDate: 2022-06-16T11:00:00-03:00
+    TrueEndDate:
+    DurationSeconds: 0
+    TotalSamples: 0
+    Channels: 2
+    SampleRateHertz: 44100
+    BitsPerSecond: 1411200
+    BitDepth: 16
+    FileSizeBytes: 634142764
+    MediaType: audio/flac
+    CalculatedChecksum:
+      Type: SHA256
+      Value: 56180427da913b3f33b969ccb788106b4693a0f80cafbbe4cd567337d69c567c
+    EmbeddedChecksum:
+      Type: MD5
+      Value: 00000000000000000000000000000000
+    MemoryCard:
+      FormatType:
+      ManufacturerID: 3
+      OEMID: SD
+      ProductName: SD256
+      ProductRevision: 8.5
+      SerialNumber: 3356670278
+      ManufactureDate: 2021-02
+      Speed:
+      Capacity:
+      WrCurrentVmin:
+      WrCurrentVmax:
+      WriteBlSize:
+      EraseBlSize:
+    Sensor:
+      Make: Frontier Labs
+      Model:
+      Name:
+      Firmware: 3.30
+      SerialNumber: 00008516
+      PowerSource:
+      Microphones:
+        - Type: STD AUDIO MIC
+          UID: 006277
+          BuildDate: 2020-01-16
+          Gain: 40
+          Channel: 0
+          ChannelName: A
+          Sensitivity:
+        - Type: STD AUDIO MIC
+          UID: 006278
+          BuildDate: 2020-01-16
+          Gain: 40
+          Channel: 1
+          ChannelName: B
+          Sensitivity:
+      Gain:
+      Configuration:
+      Voltage: 3.75
+      BatteryLevel: 0.62
+      Temperature:
+      LastTimeSync: 2022-06-15T12:04:42-03:00
+    Location:
+      Longitude: -65.95158
+      LongitudePrecision: 4
+      Latitude: 43.7058
+      LatitudePrecision: 4
+      Altitude:
+      AltitudePrecision:
+      HorizontalAccuracy:
+      VerticalAccuracy:
+      Speed:
+      Course:
+      SampleDateTime:
+      CoordinateReferenceSystem:
+  FixturePath: FL_BAR_LT/3.30_PartialDataFiles2/data
+  Notes: >
+    Partial data file that triggers a fault in our decoder.
+    Only 60,203,008 samples (115,080,383) bytes of this file are FLAC.
+    The FLAC decoder, audacity, and ffmpeg all stop decoding in the same spot, so we do as well.
+  ValidMetadata: Yes
+  MimeType: audio/flac
+  Make: Frontier Labs
+  Problems:
+    - FL011
+  Process:
+    FlacHeaderExtractor: ~
+    FlacCommentExtractor: ~
+    FilenameExtractor:
+      <<: *FL011Bug346
+      StartDate: ~
+      LocalStartDate: ~
+      TrueStartDate: ~
+      TrueEndDate: ~
+      Sensor: ~
+      Location: ~
+      MemoryCard: ~


### PR DESCRIPTION
Fixes #346

Mainly: by not throwing in CalculateSampleCountFromFrameList we allow the backup method of counting frames to work. This particular bug was caused because the full file scan method was used to verify FL011, but the Fl010 detection started with the end-only method, and threw when it found invalid frames (WAVE data).

Also fixes a bug where the FL011 fixer in dry mode would touch files that would be made (it left  them empty). No no extra files are produced.